### PR TITLE
feat: add keepalive config in data client

### DIFF
--- a/src/BigtableClient.php
+++ b/src/BigtableClient.php
@@ -113,6 +113,10 @@ class BigtableClient
         // Workaround for large messages.
         $config['transportConfig']['grpc']['stubOpts'] += [
             'grpc.max_send_message_length' => -1,
+            // Set 30s as Google Frontends allows keepalive pings at 30s
+            'grpc.keepalive_time_ms' => 30,
+            // Conservative timeout at 10s
+            'grpc.keepalive_timeout_ms' => 10000,
             'grpc.max_receive_message_length' => -1
         ];
 


### PR DESCRIPTION
Sets KeepAlive timer to 30s (Google Frontends are configured limits keepalive calls at 30s by default. If used below 30s, grpc automatically increases keepalive time by 2x after too_many_ping commands).

Sets KeepAliveTimeout to 10s (conservative)