### PR TITLE
feat: add pingAndWarm option to BigtableClient (1.28.x)

### DIFF
--- a/src/BigtableClient.php
+++ b/src/BigtableClient.php
@@ -60,6 +60,11 @@ class BigtableClient
     private $pingAndWarm;
 
     /**
+     * @var array
+     */
+    private $pingAndWarmCalled = [];
+
+    /**
      * Create a Bigtable client.
      *
      * @param array $config [optional] {
@@ -162,10 +167,11 @@ class BigtableClient
      */
     public function table($instanceId, $tableId, array $options = [])
     {
-        if ($this->pingAndWarm) {
+        if ($this->pingAndWarm && !($this->pingAndWarmCalled[$instanceId] ?? false)) {
             $this->gapicClient->pingAndWarm(
                 GapicClient::instanceName($this->projectId, $instanceId)
             );
+            $this->pingAndWarmCalled[$instanceId] = true;
         }
 
         return new Table(

--- a/src/BigtableClient.php
+++ b/src/BigtableClient.php
@@ -54,12 +54,18 @@ class BigtableClient
     private $projectId;
 
     /**
+     * Invoke {@see GapicClient::pingAndWarm()} when {@see self::table()} is called
+     * in order to establish a persistent gRPC channel before making an RPC call.
+     *
      * @experimental
      * @var bool
      */
     private $pingAndWarm;
 
     /**
+     * An in-memory static array to ensure pingAndWarm is only called once per instance.
+     *
+     * @experimental
      * @var array
      */
     private static $pingAndWarmCalled = [];

--- a/src/BigtableClient.php
+++ b/src/BigtableClient.php
@@ -164,7 +164,7 @@ class BigtableClient
     {
         if ($this->pingAndWarm) {
             $this->gapicClient->pingAndWarm(
-                $this->gapicClient->instanceName($this->projectId, $instanceId)
+                GapicClient::instanceName($this->projectId, $instanceId)
             );
         }
 

--- a/src/BigtableClient.php
+++ b/src/BigtableClient.php
@@ -168,6 +168,9 @@ class BigtableClient
     public function table($instanceId, $tableId, array $options = [])
     {
         if ($this->pingAndWarm && !($this->pingAndWarmCalled[$instanceId] ?? false)) {
+            // The default deadline is configured by the "clientConfig" option, which uses
+            // `src/V2/resources/bigtable_client_config.json`.
+            // This default deadline should be high enough to absorb cold connection latencies.
             $this->gapicClient->pingAndWarm(
                 GapicClient::instanceName($this->projectId, $instanceId)
             );

--- a/src/BigtableClient.php
+++ b/src/BigtableClient.php
@@ -62,7 +62,7 @@ class BigtableClient
     /**
      * @var array
      */
-    private $pingAndWarmCalled = [];
+    private static $pingAndWarmCalled = [];
 
     /**
      * Create a Bigtable client.
@@ -167,14 +167,15 @@ class BigtableClient
      */
     public function table($instanceId, $tableId, array $options = [])
     {
-        if ($this->pingAndWarm && !($this->pingAndWarmCalled[$instanceId] ?? false)) {
-            // The default deadline is configured by the "clientConfig" option, which uses
-            // `src/V2/resources/bigtable_client_config.json`.
-            // This default deadline should be high enough to absorb cold connection latencies.
-            $this->gapicClient->pingAndWarm(
-                GapicClient::instanceName($this->projectId, $instanceId)
-            );
-            $this->pingAndWarmCalled[$instanceId] = true;
+        if ($this->pingAndWarm) {
+            $instanceName = GapicClient::instanceName($this->projectId, $instanceId);
+            if (!(self::$pingAndWarmCalled[$instanceName] ?? false)) {
+                // The default deadline is configured by the "clientConfig" option, which uses
+                // `src/V2/resources/bigtable_client_config.json`.
+                // This default deadline should be high enough to absorb cold connection latencies.
+                $this->gapicClient->pingAndWarm($instanceName);
+                self::$pingAndWarmCalled[$instanceName] = true;
+            }
         }
 
         return new Table(

--- a/tests/Unit/BigtableClientTest.php
+++ b/tests/Unit/BigtableClientTest.php
@@ -82,6 +82,7 @@ class BigtableClientTest extends TestCase
         $bigtable = new BigtableClient([
             'projectId' => 'my-project',
             'credentials' => new InsecureCredentialsWrapper(),
+            'gapicClient' => $gapicClient->reveal(),
             'pingAndWarm' => true,
         ]);
         (fn() => $this->gapicClient = $gapicClient->reveal())->call($bigtable);
@@ -91,17 +92,5 @@ class BigtableClientTest extends TestCase
         $bigtable->table('my-instance', 'my-table'); // not called
         $bigtable->table('my-instance', 'my-table-2'); // still not called
         $bigtable->table('my-instance-2', 'my-table'); // called
-
-        // creating a new client with the same projectId still will not call pingandwarm more than
-        // once per instance
-        $bigtable = new BigtableClient([
-            'projectId' => 'my-project',
-            'credentials' => new InsecureCredentialsWrapper(),
-            'pingAndWarm' => true,
-        ]);
-
-        $bigtable->table('my-instance', 'my-table'); // still not called
-        $bigtable->table('my-instance', 'my-table-2'); // still not called
-        $bigtable->table('my-instance-2', 'my-table'); // still not called
     }
 }

--- a/tests/Unit/BigtableClientTest.php
+++ b/tests/Unit/BigtableClientTest.php
@@ -72,7 +72,10 @@ class BigtableClientTest extends TestCase
             'pingAndWarm' => true, // this would throw an auth error if it was called
         ]);
 
-        $gapicClient->pingAndWarm(Argument::any())
+        $gapicClient = $this->prophesize(BigtableGapicClient::class);
+        $gapicClient->pingAndWarm('projects/my-project/instances/my-instance')
+            ->shouldBeCalledOnce();
+        $gapicClient->pingAndWarm('projects/my-project/instances/my-instance-2')
             ->shouldBeCalledOnce();
 
         // calling "::table" with the option should call pingandwarm
@@ -84,5 +87,10 @@ class BigtableClientTest extends TestCase
         ]);
         (fn() => $this->gapicClient = $gapicClient->reveal())->call($bigtable);
         $bigtable->table('my-instance', 'my-table');
+
+        // "PingAndWarm" will only be called once per instance
+        $bigtable->table('my-instance', 'my-table'); // not called
+        $bigtable->table('my-instance', 'my-table-2'); // still not called
+        $bigtable->table('my-instance-2', 'my-table'); // called
     }
 }

--- a/tests/Unit/BigtableClientTest.php
+++ b/tests/Unit/BigtableClientTest.php
@@ -18,10 +18,13 @@
 namespace Google\Cloud\Bigtable\Tests\Unit;
 
 use Google\Cloud\Bigtable\BigtableClient;
+use Google\Cloud\Bigtable\V2\BigtableClient as BigtableGapicClient;
 use Google\Cloud\Bigtable\Table;
 use Google\Cloud\Core\InsecureCredentialsWrapper;
 use Google\Cloud\Core\Testing\TestHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @group bigtable
@@ -29,6 +32,8 @@ use PHPUnit\Framework\TestCase;
  */
 class BigtableClientTest extends TestCase
 {
+    use ProphecyTrait;
+
     private $client;
 
     public function setUp(): void
@@ -43,5 +48,41 @@ class BigtableClientTest extends TestCase
         $table = $this->client->table('my-instance', 'my-table');
 
         $this->assertInstanceOf(Table::class, $table);
+    }
+
+    public function testPingAndWarm()
+    {
+        $gapicClient = $this->prophesize(BigtableGapicClient::class);
+        $gapicClient->pingAndWarm(Argument::any())
+            ->shouldNotBeCalled();
+
+        $bigtable = new BigtableClient([
+            'projectId' => 'my-project',
+            'credentials' => new InsecureCredentialsWrapper(),
+        ]);
+        (fn() => $this->gapicClient = $gapicClient->reveal())->call($bigtable);
+
+        // calling "::table" without the option does not pingandwarm
+        $table = $bigtable->table('my-instance', 'my-table');
+
+        // creating the client with the option does not pingandwarm
+        $bigtable = new BigtableClient([
+            'projectId' => 'my-project',
+            'credentials' => new InsecureCredentialsWrapper(),
+            'pingAndWarm' => true, // this would throw an auth error if it was called
+        ]);
+
+        $gapicClient->pingAndWarm(Argument::any())
+            ->shouldBeCalledOnce();
+
+        // calling "::table" with the option should call pingandwarm
+        $bigtable = new BigtableClient([
+            'projectId' => 'my-project',
+            'credentials' => new InsecureCredentialsWrapper(),
+            'gapicClient' => $gapicClient->reveal(),
+            'pingAndWarm' => true,
+        ]);
+        (fn() => $this->gapicClient = $gapicClient->reveal())->call($bigtable);
+        $bigtable->table('my-instance', 'my-table');
     }
 }

--- a/tests/Unit/BigtableClientTest.php
+++ b/tests/Unit/BigtableClientTest.php
@@ -82,7 +82,6 @@ class BigtableClientTest extends TestCase
         $bigtable = new BigtableClient([
             'projectId' => 'my-project',
             'credentials' => new InsecureCredentialsWrapper(),
-            'gapicClient' => $gapicClient->reveal(),
             'pingAndWarm' => true,
         ]);
         (fn() => $this->gapicClient = $gapicClient->reveal())->call($bigtable);
@@ -92,5 +91,17 @@ class BigtableClientTest extends TestCase
         $bigtable->table('my-instance', 'my-table'); // not called
         $bigtable->table('my-instance', 'my-table-2'); // still not called
         $bigtable->table('my-instance-2', 'my-table'); // called
+
+        // creating a new client with the same projectId still will not call pingandwarm more than
+        // once per instance
+        $bigtable = new BigtableClient([
+            'projectId' => 'my-project',
+            'credentials' => new InsecureCredentialsWrapper(),
+            'pingAndWarm' => true,
+        ]);
+
+        $bigtable->table('my-instance', 'my-table'); // still not called
+        $bigtable->table('my-instance', 'my-table-2'); // still not called
+        $bigtable->table('my-instance-2', 'my-table'); // still not called
     }
 }


### PR DESCRIPTION
Add a client option to call the `pingAndWarm` RPC when pulling a table

```php
// nothing changes
$bigtable = new BigtableClient(['pingAndWarm' => true]);

// this will call the "PingAndWarm" RPC to warm the gRPC channel
$table = $bigtable->table('my-table');
```